### PR TITLE
修复单工通信时，通信通道被关闭问题

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,7 +43,11 @@ func main() {
 	}
 
 	// init logger server
-	initLogger()
+	err := initLogger()
+	if err != nil {
+		fmt.Println("init logger failed,", err)
+		return
+	}
 
 	// init Backend server
 	initBackendSvrs(pConfig.Backend)

--- a/proxy.go
+++ b/proxy.go
@@ -5,6 +5,8 @@ package main
 import (
 	"net"
 	"time"
+	//"fmt"
+	"io"
 )
 
 func initProxy() {
@@ -89,15 +91,21 @@ func pass(from net.Conn, to net.Conn, complete chan bool, oneSide chan bool, oth
 
 			from.SetReadDeadline(time.Now().Add(time.Duration(pConfig.Timeout) * time.Second))
 			read, err = from.Read(bytes)
+			//fmt.Println("read data from:", from.(*net.TCPConn).RemoteAddr())
 			if err != nil {
+				//fmt.Println("read data from:", from.(*net.TCPConn).RemoteAddr(), "failed", err)
 				complete <- true
-				oneSide <- true
+				if err != io.EOF {
+					oneSide <- true
+				}
 				return
 			}
 
 			to.SetWriteDeadline(time.Now().Add(time.Duration(pConfig.Timeout) * time.Second))
 			_, err = to.Write(bytes[:read])
+			//fmt.Println("write data to:", to.(*net.TCPConn).RemoteAddr())
 			if err != nil {
+				//fmt.Println("write data to:", to.(*net.TCPConn).RemoteAddr(), "failed", err)
 				complete <- true
 				oneSide <- true
 				return


### PR DESCRIPTION
完善两点：
1、日志目录有多级不存在时，目录创建不了问题
2、单工通信时（只有单向的数据，比如客户端将读关闭，服务端将写关闭），proxy从服务端读取数据，会读到EOF，这时就会将proxy的连接都关闭，也无法从客户端读数据了
